### PR TITLE
Update .gitignore for debug and error logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 bower_components
 node_modules
 build
+package-lock.json
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
**Update .gitignore for yarn logs**

- This PR updates `.gitignore` to ignore debug and error logs generated by yarn/npm.