### PR TITLE
Mention patching as one of the main features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [Vega-Embed](http://github.com/vega/vega-embed) makes it easy to embed interactive [Vega](https://vega.github.io/vega) and [Vega-Lite](https://vega.github.io/vega-lite) views into web pages. With Vega Embed, you can:
 
 - Load Vega/Vega-Lite specs from source text, parsed JSON, or URLs.
-- Patch Vega/Vega-Lite specs to add additional functionality; for example, see [Rotating Earth](https://observablehq.com/@domoritz/rotating-earth).
+- Patch Vega specs (even ones generated from Vega-Lite) to add additional functionality; for example, see [Rotating Earth](https://observablehq.com/@domoritz/rotating-earth).
 - Add action links such as "View Source" and "Open in Vega Editor".
 - Includes [Vega Tooltip](https://github.com/vega/vega-tooltip).
 - Includes [Vega Themes](https://github.com/vega/vega-themes). **Experimental: themes are not stable yet**


### PR DESCRIPTION
Per discussion with @domoritz on Slack, I think highlighting patching as a main feature of vega-embed will be helpful. I feel it's hidden in the docs and folks (like myself) may not seek it out as a result. I had the mistaken impression that vega-embed was either/or — Vega or Vega Lite — and as a result I always converted my Vega Lite specs to Vega when I needed to accomplish something more. Now that I've learned about `patch` I can retain simpler, easier Vega Lite specs and patch in what I need.