### PR TITLE
Remove document click event listener on finalize.

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -335,7 +335,7 @@ async function _embed(
 
   await view.initialize(el).runAsync();
 
-  let documentClickHandler: ((evt: Event) => void) | undefined;
+  let documentClickHandler: ((this: Document, ev: MouseEvent) => void) | undefined;
 
   if (actions !== false) {
     let wrapper = div;
@@ -351,8 +351,8 @@ async function _embed(
 
       details.append(summary);
 
-      documentClickHandler = (evt: Event) => {
-        if (!details.contains(evt.target as any)) {
+      documentClickHandler = (ev: MouseEvent) => {
+        if (!details.contains(ev.target as any)) {
           details.removeAttribute('open');
         }
       };

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -335,6 +335,8 @@ async function _embed(
 
   await view.initialize(el).runAsync();
 
+  let documentClickHandler: ((evt: Event) => void) | undefined;
+
   if (actions !== false) {
     let wrapper = div;
 
@@ -349,11 +351,12 @@ async function _embed(
 
       details.append(summary);
 
-      document.addEventListener('click', evt => {
+      documentClickHandler = (evt: Event) => {
         if (!details.contains(evt.target as any)) {
           details.removeAttribute('open');
         }
-      });
+      };
+      document.addEventListener('click', documentClickHandler);
     }
 
     const ctrl = document.createElement('div');
@@ -435,6 +438,16 @@ async function _embed(
 
       ctrl.append(editorLink);
     }
+  }
+
+  // Wrap view.finalize to also remove event listeners from Vega-Embed.
+  if (documentClickHandler) {
+    const originalFinalize = view.finalize;
+    view.finalize = () => {
+      document.removeEventListener('click', documentClickHandler!);
+
+      originalFinalize();
+    };
   }
 
   return { view, spec, vgSpec };

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -442,7 +442,7 @@ async function _embed(
 
   // Wrap view.finalize to also remove event listeners from Vega-Embed.
   if (documentClickHandler) {
-    const originalFinalize = view.finalize;
+    const originalFinalize = view.finalize.bind(view);
     view.finalize = () => {
       document.removeEventListener('click', documentClickHandler!);
 


### PR DESCRIPTION
Fixes #270

My leak test spec

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <title>Vega-Embed for Vega</title>

    <script src="https://cdn.jsdelivr.net/npm/vega@5.8.1"></script>
    <script src="build/vega-embed.js"></script>
  </head>

  <body>
    <div id="vis"></div>
    <script>
      const spec = {
        $schema: "https://vega.github.io/schema/vega/v5.json",
        width: 400,
        height: 200,
        padding: 5,

        data: [
          {
            name: "table",
            values: [
              { category: "A", amount: 28 },
              { category: "B", amount: 55 },
              { category: "C", amount: 43 },
              { category: "D", amount: 91 },
              { category: "E", amount: 81 },
              { category: "F", amount: 53 },
              { category: "G", amount: 19 },
              { category: "H", amount: 87 }
            ]
          }
        ],

        signals: [
          {
            name: "tooltip",
            value: {},
            on: [
              { events: "rect:mouseover", update: "datum" },
              { events: "rect:mouseout", update: "{}" }
            ]
          }
        ],

        scales: [
          {
            name: "xscale",
            type: "band",
            domain: { data: "table", field: "category" },
            range: "width",
            padding: 0.05,
            round: true
          },
          {
            name: "yscale",
            domain: { data: "table", field: "amount" },
            nice: true,
            range: "height"
          }
        ],

        axes: [
          { orient: "bottom", scale: "xscale" },
          { orient: "left", scale: "yscale" }
        ],

        marks: [
          {
            type: "rect",
            from: { data: "table" },
            encode: {
              enter: {
                x: { scale: "xscale", field: "category" },
                width: { scale: "xscale", band: 1 },
                y: { scale: "yscale", field: "amount" },
                y2: { scale: "yscale", value: 0 }
              },
              update: {
                fill: { value: "steelblue" }
              },
              hover: {
                fill: { value: "red" }
              }
            }
          },
          {
            type: "text",
            encode: {
              enter: {
                align: { value: "center" },
                baseline: { value: "bottom" },
                fill: { value: "#333" }
              },
              update: {
                x: { scale: "xscale", signal: "tooltip.category", band: 0.5 },
                y: { scale: "yscale", signal: "tooltip.amount", offset: -2 },
                text: { signal: "tooltip.amount" },
                fillOpacity: [{ test: "datum === tooltip", value: 0 }, { value: 1 }]
              }
            }
          }
        ]
      };

      async function run() {
        let view = null;

        let counter = 100;

        const f = async () => {
          if (view) {
            view.finalize();
          }

          const result = await vegaEmbed("#vis", spec);
          view = result.view;

          console.log("new view");

          if (!counter--) {
            clearInterval(id);
            console.log("stop");
          }
        };

        const id = setInterval(f, 400);
      }

      run();
    </script>
  </body>
</html>
```

Before:
<img width="1071" alt="Screen Shot 2019-11-26 at 13 01 59" src="https://user-images.githubusercontent.com/589034/69672856-cf9e3680-104d-11ea-9cae-af9ca0aba028.png">

After:
<img width="1074" alt="Screen Shot 2019-11-26 at 13 10 38" src="https://user-images.githubusercontent.com/589034/69672992-2ad02900-104e-11ea-8dc0-4b47d32b3730.png">

