### PR TITLE
BUG: support padding=0

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -330,7 +330,7 @@ async function _embed(
     if (opts.height) {
       view.height(opts.height);
     }
-    if (opts.padding) {
+    if (opts.padding || opts.padding === 0) {
       view.padding(opts.padding);
     }
   }


### PR DESCRIPTION
Currently in embed options, ``{"padding": 0}`` is treated as if padding is not specified.