### PR TITLE
Security: specify editor origin in post message

### DIFF
--- a/src/post.ts
+++ b/src/post.ts
@@ -24,7 +24,7 @@ export default function (window: Window, url: string, data: MessageData) {
     if (count <= 0) {
       return;
     }
-    editor.postMessage(data, '*');
+    editor.postMessage(data, editor.origin);
     setTimeout(send, step);
     count -= 1;
   }


### PR DESCRIPTION
Why? The current approach of using `"*"` would potentially allow malicious code to intercept a user's data. See https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#Security_concerns