### PR TITLE
fix: allow for embedding styles in shadowRoot

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -246,7 +246,7 @@ async function _embed(
 
   const div = typeof el === 'string' ? document.querySelector(el) : el;
   if (!div) {
-    throw Error(`${el} does not exist`);
+    throw new Error(`${el} does not exist`);
   }
 
   if (opts.defaultStyle !== false) {

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -229,6 +229,20 @@ async function loadOpts(opt: EmbedOptions, loader: Loader): Promise<EmbedOptions
   };
 }
 
+function getRoot(el: Element) {
+  const possibleRoot = div.getRootNode ? div.getRootNode() : document;
+  let root: ShadowRoot | Document;
+  let rootContainer: Element | ShadowRoot;
+  if (possibleRoot instanceof ShadowRoot) {
+    root = possibleRoot;
+    rootContainer = root;
+  } else {
+    root = document;
+    rootContainer = root.head ?? root.body;
+  }
+  return { root, rootContainer };
+}
+
 async function _embed(
   el: HTMLElement | string,
   spec: VisualizationSpec,
@@ -252,16 +266,7 @@ async function _embed(
   if (opts.defaultStyle !== false) {
     // Add a default stylesheet to the head of the document.
     const ID = 'vega-embed-style';
-    const possibleRoot = div.getRootNode ? div.getRootNode() : document;
-    let root: ShadowRoot | Document;
-    let rootContainer: Element | ShadowRoot;
-    if (possibleRoot instanceof ShadowRoot) {
-      root = possibleRoot;
-      rootContainer = root;
-    } else {
-      root = document;
-      rootContainer = root.head ?? root.body;
-    }
+    const { root, rootContainer } = getRoot(div);
     if (!root.getElementById(ID)) {
       const style = document.createElement('style');
       style.id = ID;

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -244,18 +244,32 @@ async function _embed(
   const logLevel = opts.logLevel ?? vega.Warn;
   const downloadFileName = opts.downloadFileName ?? 'visualization';
 
+  const div = typeof el === 'string' ? document.querySelector(el) : el;
+  if (!div) {
+    throw Error(`${el} does not exist`);
+  }
+
   if (opts.defaultStyle !== false) {
     // Add a default stylesheet to the head of the document.
     const ID = 'vega-embed-style';
-    if (!document.getElementById(ID)) {
+    const possibleRoot = div.getRootNode ? div.getRootNode() : document;
+    let root: ShadowRoot | Document;
+    let rootContainer: Element | ShadowRoot;
+    if (possibleRoot instanceof ShadowRoot) {
+      root = possibleRoot;
+      rootContainer = root;
+    } else {
+      root = document;
+      rootContainer = root.head || root.body;
+    }
+    if (!root.getElementById(ID)) {
       const style = document.createElement('style');
       style.id = ID;
       style.innerText =
         opts.defaultStyle === undefined || opts.defaultStyle === true
           ? (embedStyle ?? '').toString()
           : opts.defaultStyle;
-
-      document.head.appendChild(style);
+      rootContainer.appendChild(style);
     }
   }
 
@@ -271,11 +285,6 @@ async function _embed(
         console.warn(`The compiled spec uses Vega ${parsed.version}, but current version is v${VERSION.vega}.`);
       }
     }
-  }
-
-  const div = typeof el === 'string' ? document.querySelector(el) : el;
-  if (!div) {
-    throw Error(`${el} does not exist`);
   }
 
   div.classList.add('vega-embed');

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -230,7 +230,7 @@ async function loadOpts(opt: EmbedOptions, loader: Loader): Promise<EmbedOptions
 }
 
 function getRoot(el: Element) {
-  const possibleRoot = div.getRootNode ? div.getRootNode() : document;
+  const possibleRoot = el.getRootNode ? el.getRootNode() : document;
   let root: ShadowRoot | Document;
   let rootContainer: Element | ShadowRoot;
   if (possibleRoot instanceof ShadowRoot) {

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -260,7 +260,7 @@ async function _embed(
       rootContainer = root;
     } else {
       root = document;
-      rootContainer = root.head || root.body;
+      rootContainer = root.head ?? root.body;
     }
     if (!root.getElementById(ID)) {
       const style = document.createElement('style');


### PR DESCRIPTION
Fixes #477

Use getRootNode instead of assuming document as the root element.