### PR TITLE
refactor: import only default from JSON files for webpack 5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import pkg from '../package.json';
 import container from './container';
 import embed, {vega, vegaLite} from './embed';
 import {isURL} from './util';
+
 /**
  * Returns true if the object is an HTML element.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import {isString} from 'vega';
-import {version} from '../package.json';
+import pkg from '../package.json';
 import container from './container';
 import embed, {vega, vegaLite} from './embed';
 import {isURL} from './util';
@@ -27,6 +27,6 @@ const wrapper: Wrapper = (...args: any[]): any => {
 (wrapper as any).embed = embed;
 (wrapper as any).vega = vega;
 (wrapper as any).default = embed;
-(wrapper as any).version = version;
+(wrapper as any).version = pkg.version;
 
 export default wrapper;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import pkg from '../package.json';
 import container from './container';
 import embed, {vega, vegaLite} from './embed';
 import {isURL} from './util';
-
 /**
  * Returns true if the object is an HTML element.
  */


### PR DESCRIPTION
Webpack no longer supports using named exports from JSON modules (https://webpack.js.org/migrate/5/#cleanup-the-code)

It looks like a similar update was made in vega-lite here https://github.com/vega/vega-lite/pull/7029