### PR TITLE
fix: use babel preset config to support es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "del-cli": "^3.0.1",
     "jest-canvas-mock": "^2.3.1",
     "node-sass": "^6.0.0",
-    "rollup": "^2.47.0",
+    "rollup": "2.46.0",
     "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.2.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,8 @@ const plugins = (browserslist, declaration) => [
       declaration,
       declarationMap: declaration,
     }),
+    transpiler: "babel",
+    babelConfig: {"presets": ["@babel/preset-env"]},
     browserslist,
   }),
   bundleSize(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6780,10 +6780,10 @@ rollup-plugin-terser@^7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.47.0:
-  version "2.47.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.47.0.tgz#9d958aeb2c0f6a383cacc0401dff02b6e252664d"
-  integrity sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==
+rollup@2.46.0:
+  version "2.46.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.46.0.tgz#8cacf89d2ee31a34755f1af40a665168f592b829"
+  integrity sha512-qPGoUBNl+Z8uNu0z7pD3WPTABWRbcOwIrO/5ccDJzmrtzn0LVf6Lj91+L5CcWhXl6iWf23FQ6m8Jkl2CmN1O7Q==
   optionalDependencies:
     fsevents "~2.3.1"
 


### PR DESCRIPTION
This addresses #684. I verified that the newly compiled es5 build works in IE 11.  

**Changes:**
- Switched rollup to previous version to get around build issue
- Added babel preset config to rollup config so that it doesn't use the babel.config.js config used for jest

FWIW, here's the JS and polyfills I had to use:

```html
<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.4.4/polyfill.min.js"></script>
<script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@3.0.0/dist/fetch.umd.min.js"></script>
<script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.5.0/bundles/webcomponents-sd.js"></script>
<script src="https://cdn.jsdelivr.net/npm/vega@5/build-es5/vega.min.js"></script>
<script src="https://cdn.jsdelivr.net/npm/vega-lite@4/build-es5/vega-lite.min.js"></script>
<script src="build-es5/vega-embed.min.js' %}"></script>
<script>
  vegaEmbed(...)
</script>
```
