### PR TITLE
Add embed option exportDataSet to set the data used when opening source/opening in editor

### DIFF
--- a/test-changeset.html
+++ b/test-changeset.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vega-Embed for Vega-Lite</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@4"></script>
+    <script src="build/vega-embed.js"></script>
+  </head>
+  <body>
+    <h1>Template for Embedding Vega-Lite Visualization</h1>
+    <div id="vis"></div>
+
+    <script>
+      const vlSpec = {
+        $schema: "https://vega.github.io/schema/vega-lite/v4.json",
+        data: { name: "table" },
+        width: 400,
+        mark: "line",
+        encoding: {
+          x: { field: "x", type: "quantitative", scale: { zero: false } },
+          y: { field: "y", type: "quantitative" },
+          color: { field: "category", type: "nominal" },
+        },
+      };
+      vegaEmbed("#vis", vlSpec, { exportDataSet: "table" }).then(function (res) {
+        /**
+         * Generates a new tuple with random walk.
+         */
+        function newGenerator() {
+          let counter = -1;
+          let previousY = [5, 5, 5, 5];
+          return function () {
+            counter++;
+            const newVals = previousY.map(function (v, c) {
+              return {
+                x: counter,
+                y: v + Math.round(Math.random() * 10 - c * 3),
+                category: c,
+              };
+            });
+            previousY = newVals.map(function (v) {
+              return v.y;
+            });
+            return newVals;
+          };
+        }
+
+        const valueGenerator = newGenerator();
+        let minimumX = -100;
+        let counter = 0;
+        const looper = window.setInterval(function () {
+          minimumX++;
+          const changeSet = vega
+            .changeset()
+            .insert(valueGenerator())
+            .remove(function (t) {
+              return t.x < minimumX;
+            });
+          res.view.change("table", changeSet).run();
+
+          if (counter++ >= 5) {
+            window.clearInterval(looper);
+          }
+        }, 1000);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #719 

This PR adds a new optional embed option `exportDataSet`. If it is set, then when the "Open Source" and "Open in Vega Editor" actions are used the data set given is used as the `data.values` of the spec before it is opened.

This means that it is possible to use Vega's changeset functionality to modify the data, and then open source/editor to eg. extract the latest data or to iterate on the chart in the editor with the latest data available.

I've also added an example file `test-changeset.html` which demonstrates this feature (and changesets more widely). This is based on the streaming demo: https://vega.github.io/vega-lite/tutorials/streaming.html 

Here's a short video showing this working. Note that without this PR the data would be empty in both cases and the editor wouldn't render any data. 

https://user-images.githubusercontent.com/1711350/126404545-c371a801-35a9-4044-b749-6567d47561d7.mov
