### PR TITLE
feat: Add a logger to embed init options

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ var opt = {
 | `defaultStyle` | Boolean or String | If set to `true` (default), the embed actions are shown in a menu. Set to `false` to use simple links. Provide a string to set the style sheet. |
 | `bind`        | String or Element | The element that should contain any input elements bound to signals. |
 | `renderer`    | String        | The renderer to use for the view. One of `"canvas"` (default) or `"svg"`. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_renderer) for details. May be a custom value if passing your own `viewClass` option. |
+| `logger`      | Object        | Sets a custom logger handler. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_logger) for details. It must follow the interface of [the original one](https://github.com/vega/vega/tree/master/packages/vega-util#logger). |
 | `logLevel`    | Level         | Sets the current log level. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_logLevel) for details. |
 | `tooltip`     | Handler or Boolean or Object | Provide a [tooltip handler](https://vega.github.io/vega/docs/api/view/#view_tooltip), customize the default [Vega Tooltip](https://github.com/vega/vega-tooltip) handler, or disable the default handler. |
 | `loader`      | Loader / Object | _Loader_ : Sets a custom Vega loader. _Object_ : Vega loader options for a loader that will be created. <br> See [Vega docs](https://vega.github.io/vega/docs/api/view/#view) for details. |

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ var opt = {
 | `defaultStyle` | Boolean or String | If set to `true` (default), the embed actions are shown in a menu. Set to `false` to use simple links. Provide a string to set the style sheet. |
 | `bind`        | String or Element | The element that should contain any input elements bound to signals. |
 | `renderer`    | String        | The renderer to use for the view. One of `"canvas"` (default) or `"svg"`. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_renderer) for details. May be a custom value if passing your own `viewClass` option. |
-| `logger`      | Object        | Sets a custom logger handler. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_logger) for details. It must follow the interface of [the original one](https://github.com/vega/vega/tree/master/packages/vega-util#logger). |
+| `logger`      | Object        | Sets a [custom logger handler on the view](https://vega.github.io/vega/docs/api/view/#view_logger). A logger must implement the [Vega logger API](https://github.com/vega/vega/tree/master/packages/vega-util#logger). |
 | `logLevel`    | Level         | Sets the current log level. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_logLevel) for details. |
 | `tooltip`     | Handler or Boolean or Object | Provide a [tooltip handler](https://vega.github.io/vega/docs/api/view/#view_tooltip), customize the default [Vega Tooltip](https://github.com/vega/vega-tooltip) handler, or disable the default handler. |
 | `loader`      | Loader / Object | _Loader_ : Sets a custom Vega loader. _Object_ : Vega loader options for a loader that will be created. <br> See [Vega docs](https://vega.github.io/vega/docs/api/view/#view) for details. |

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -10,6 +10,8 @@ import {
   isString,
   Loader,
   LoaderOptions,
+  logger as VgLogger,
+  LoggerInterface,
   mergeConfig,
   Renderers,
   Spec as VgSpec,
@@ -68,6 +70,7 @@ export interface EmbedOptions<S = string, R = Renderers> {
   mode?: Mode;
   theme?: 'excel' | 'ggplot2' | 'quartz' | 'vox' | 'dark';
   defaultStyle?: boolean | string;
+  logger?: LoggerInterface;
   logLevel?: number;
   loader?: Loader | LoaderOptions;
   renderer?: R;
@@ -275,6 +278,7 @@ async function _embed(
   const i18n = {...I18N, ...opts.i18n};
 
   const renderer = opts.renderer ?? 'canvas';
+  const logger = opts.logger ?? VgLogger();
   const logLevel = opts.logLevel ?? vega.Warn;
   const downloadFileName = opts.downloadFileName ?? 'visualization';
 
@@ -352,6 +356,7 @@ async function _embed(
 
   const view = new (opts.viewClass || vega.View)(runtime, {
     loader,
+    logger,
     logLevel,
     renderer,
     ...(ast ? {expr: (vega as any).expressionInterpreter} : {}),

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -10,7 +10,7 @@ import {
   isString,
   Loader,
   LoaderOptions,
-  logger as VgLogger,
+  logger as vegaLogger,
   LoggerInterface,
   mergeConfig,
   Renderers,
@@ -278,7 +278,7 @@ async function _embed(
   const i18n = {...I18N, ...opts.i18n};
 
   const renderer = opts.renderer ?? 'canvas';
-  const logger = opts.logger ?? VgLogger();
+  const logger = opts.logger ?? vegaLogger();
   const logLevel = opts.logLevel ?? vega.Warn;
   const downloadFileName = opts.downloadFileName ?? 'visualization';
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -304,7 +304,7 @@ async function _embed(
 
   const mode = guessMode(spec, opts.mode);
 
-  let vgSpec: VgSpec = PREPROCESSOR[mode](spec, config);
+  let vgSpec: VgSpec = PREPROCESSOR[mode](spec, { ...config, logger });
 
   if (mode === 'vega-lite') {
     if (vgSpec.$schema) {

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -385,3 +385,11 @@ test('can set loader via usermeta', async () => {
     target: '_blank',
   });
 });
+
+test('can set logger', async () => {
+  const el = document.createElement('div');
+  const logger = vega.logger();
+  const result = await embed(el, vlSpec, {logger});
+  expect(result).toBeTruthy();
+  expect((result.view as any)._log).toEqual(logger);
+});


### PR DESCRIPTION
Add an option to the `embed` function. 
It allows to pass a custom logger to the view.