### PR TITLE
test: no warnings when versions are compatible

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -350,6 +350,17 @@ test('Should warn about incompatible Vega and Vega-Lite versions', async () => {
   await embed(
     el,
     {
+      // should not cause a warning
+      $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+      mark: 'bar',
+      encoding: {},
+    },
+    {}
+  );
+
+  await embed(
+    el,
+    {
       $schema: 'https://vega.github.io/schema/vega/v4.json',
     },
     {}


### PR DESCRIPTION
Relevant to https://github.com/vega/vega-embed/issues/767
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.20.1--canary.789.594be07.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-embed@6.20.1--canary.789.594be07.0
  # or 
  yarn add vega-embed@6.20.1--canary.789.594be07.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
