### PR TITLE
fix: fix build with semver

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,6 +1,7 @@
 import {applyPatch, Operation} from 'fast-json-patch';
 import stringify from 'json-stringify-pretty-compact';
-import {satisfies} from 'semver';
+// need this import because of https://github.com/npm/node-semver/issues/381
+import satisfies from 'semver/functions/satisfies';
 import * as vegaImport from 'vega';
 import {
   AutoSize,


### PR DESCRIPTION
Fixes #767
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.20.1--canary.790.70fb595.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-embed@6.20.1--canary.790.70fb595.0
  # or 
  yarn add vega-embed@6.20.1--canary.790.70fb595.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
