### PR TITLE
fix: try bundledDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     "vega-themes": "^2.10.0",
     "vega-tooltip": "^0.27.0"
   },
+  "bundledDependencies": [
+    "yallist"
+  ],
   "scripts": {
     "prebuild": "yarn clean && yarn build:style",
     "build": "rollup -c",
@@ -90,12 +93,11 @@
     "pretest": "yarn build:style",
     "test": "beemo jest --stdio stream",
     "test:inspect": "node --inspect-brk ./node_modules/.bin/jest --runInBand",
-    "prepare": "beemo create-config",
+    "prepare": "beemo create-config && npx patch-package",
     "prettierbase": "beemo prettier '*.{css,scss,html}'",
     "eslintbase": "beemo eslint .",
     "format": "yarn eslintbase --fix && yarn prettierbase --write",
     "lint": "yarn eslintbase && yarn prettierbase --check",
-    "release": "yarn build && auto shipit",
-    "postinstall": "npx patch-package"
+    "release": "yarn build && auto shipit"
   }
 }


### PR DESCRIPTION
Fixes #806
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.20.5--canary.807.4b66f40.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-embed@6.20.5--canary.807.4b66f40.0
  # or 
  yarn add vega-embed@6.20.5--canary.807.4b66f40.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
