### PR TITLE
Declare padding as a CSS property

### DIFF
--- a/vega-embed.scss
+++ b/vega-embed.scss
@@ -5,6 +5,7 @@
 
   &.has-actions {
     padding-right: 38px;
+    --vega-action-padding: 38px;
   }
 
   details:not([open]) > :not(summary) {


### PR DESCRIPTION
Declare the `padding-right` of `.vega-embed.has-actions` as the CSS property `--vega-action-padding`.

Rationale:
1. vconcat charts often overflow
2. user wants to center the overflowing chart
3. it is impossible to center without resizing and without knowing the padding
4. hardcoded padding may deviate from upstream

Now this is possible:
```css
.vega-embed .marks {
  margin-left: 50%;
  transform:
    translateX(-50%)
    translateX(calc(var(--vega-action-padding,38px)/2));
}
```

The actual padding does not use the CSS property, ensuring nothing breaks if CSS properties are not supported by the browser.
