### PR TITLE
Adds visible focus state to actions menu (A11y fix)

### DIFF
--- a/vega-embed.scss
+++ b/vega-embed.scss
@@ -25,7 +25,6 @@
     border-radius: 999px;
     opacity: 0.2;
     transition: opacity 0.4s ease-in;
-    outline: none;
     cursor: pointer;
     line-height: 0px; // For Safari
 
@@ -48,7 +47,7 @@
   }
 
   &:hover summary,
-  &:focus summary {
+  &:focus-within summary {
     opacity: 1 !important;
     transition: opacity 0.2s ease;
   }
@@ -80,7 +79,8 @@
       color: #434a56;
       text-decoration: none;
 
-      &:hover {
+      &:hover,
+      &:focus {
         background-color: #f7f7f9;
         color: black;
       }


### PR DESCRIPTION
# Description

This PR adds a visible focus state to the actions menu. This creates a more accessible experience for keyboard users who might be using the TAB key to navigate through websites, and matches the visual styling to the mouse user's "hover" state. More info on why this is required for accessibility reasons here: [w3.org](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html)  

Here is a screen recording showing behavior via keyboard and then via mouse for reference:
![actions-focus](https://user-images.githubusercontent.com/41567007/149806696-7d43343b-45c3-4026-832e-41ea89702ed5.gif)

Specifically: 
- removes `outline: none` which was preventing the browser's default focus indication on the `<summary>` element
- additionally adds the same highlighted styling that mouse users get on "hover" to the focused actions menu's collapsed `<svg>` and to each focused `<a>` option in the expanded menu

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have deployed a test react app here for testing: https://reverent-kilby-656ff9.netlify.app/ which uses my fork for `vega-embed` 

This has been tested on the following browsers, which all show the expected styling and built-in browser focus ring when tabbed into focus using the keyboard, and proper display for normal click/touch to expand menu. Note: I have not been able to test on Windows, ChromeOS or Android. 

Mac OS11
- Safari
- Chrome
- Firefox
- Edge

iOS
- Chrome
- Safari


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (the only warning were already occurring on the `next` branch: `The input spec uses Vega-Lite v4, but the current version of Vega-Lite is v5.2.0.`)
- [x] existing unit tests pass locally with my changes


