### PR TITLE
fix: add visible focus state to actions menu for A11y

### DIFF
--- a/vega-embed.scss
+++ b/vega-embed.scss
@@ -25,7 +25,6 @@
     border-radius: 999px;
     opacity: 0.2;
     transition: opacity 0.4s ease-in;
-    outline: none;
     cursor: pointer;
     line-height: 0px; // For Safari
 
@@ -48,7 +47,7 @@
   }
 
   &:hover summary,
-  &:focus summary {
+  &:focus-within summary {
     opacity: 1 !important;
     transition: opacity 0.2s ease;
   }
@@ -80,7 +79,8 @@
       color: #434a56;
       text-decoration: none;
 
-      &:hover {
+      &:hover,
+      &:focus {
         background-color: #f7f7f9;
         color: black;
       }


### PR DESCRIPTION
Built off of https://github.com/vega/vega-embed/pull/839 by @benhammondmusic. 

Chrome: 

https://user-images.githubusercontent.com/589034/150186375-0c283708-6310-4c83-9fb7-1617e3aac67f.mov

Safari:

https://user-images.githubusercontent.com/589034/150186402-1a724fa3-ce50-49f5-bc0f-298ada8e947c.mov




<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.20.6--canary.841.78ab2d1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-embed@6.20.6--canary.841.78ab2d1.0
  # or 
  yarn add vega-embed@6.20.6--canary.841.78ab2d1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
