### PR TITLE
fix: use innerHTML to set style to avoid <br>

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -288,13 +288,12 @@ async function _embed(
   }
 
   if (opts.defaultStyle !== false) {
-    // Add a default stylesheet to the head of the document.
     const ID = 'vega-embed-style';
     const {root, rootContainer} = getRoot(element);
     if (!root.getElementById(ID)) {
       const style = document.createElement('style');
       style.id = ID;
-      style.innerText =
+      style.innerHTML =
         opts.defaultStyle === undefined || opts.defaultStyle === true
           ? (embedStyle ?? '').toString()
           : opts.defaultStyle;


### PR DESCRIPTION
fixes #856
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.20.7--canary.858.b5b98aa.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-embed@6.20.7--canary.858.b5b98aa.0
  # or 
  yarn add vega-embed@6.20.7--canary.858.b5b98aa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
