### PR TITLE
fix(docs): update `padding` type and mention the Yarn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ var opt = {
 | `patch`       | Function / Object[] / String | A function to modify the Vega specification before it is parsed. Alternatively, a [JSON-Patch RFC6902](https://tools.ietf.org/html/rfc6902) to modify the Vega specification. If you use Vega-Lite, the compiled Vega will be patched. Alternatively to the function or the object, a URL string from which to load the patch can be provided. This URL will be subject to standard browser security restrictions. Typically this URL will point to a file on the same host and port number as the web page itself. |
 | `width`       | Number        | Sets the view width in pixels. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_width) for details. Note that Vega-Lite overrides this option. |
 | `height`      | Number        | Sets the view height in pixels. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_height) for details. Note that Vega-Lite overrides this option. |
-| `padding`     | Object        | Sets the view padding in pixels. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_padding) for details. |
+| `padding`     | Number / Object | Sets the view padding in pixels. See [Vega docs](https://vega.github.io/vega/docs/api/view/#view_padding) for details. |
 | `actions`     | Boolean / Object | Determines if action links ("Export as PNG/SVG", "View Source", "View Vega" (only for Vega-Lite), "Open in Vega Editor") are included with the embedded view. If the value is `true`, all action links will be shown and none if the value is `false`.  This property can take a key-value mapping object that maps keys (`export`, `source`, `compiled`, `editor`) to boolean values for determining if each action link should be shown.  By default, `export`, `source`, and `editor` are true and `compiled` is false. These defaults can be overridden: for example, if `actions` is `{export: false, source: true}`, the embedded visualization will have two links – "View Source" and "Open in Vega Editor".  The `export` property can take a key-value mapping object that maps keys (svg, png) to boolean values for determining if each export action link should be shown. By default, `svg` and `png` are true. |
 | `scaleFactor` | Number        | The number by which to multiply the width and height (default `1`) of an exported PNG or SVG image. |
 | `editorUrl`    | String   | The URL at which to open embedded Vega specs in a Vega editor. Defaults to `"http://vega.github.io/editor/"`. Internally, Vega-Embed uses [HTML5 postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to pass the specification information to the editor. |
@@ -216,7 +216,7 @@ When using [container](https://vega.github.io/vega-lite/docs/size.html#specifyin
 
 ## Build Process
 
-To build `vega-embed.js` and view the test examples, you must have [yarn](https://yarnpkg.com/en/) installed.
+To build `vega-embed.js` and view the test examples, you must have [Yarn 1](https://classic.yarnpkg.com/) installed.
 
 1. Run `yarn` in the Vega-Embed folder to install dependencies.
 2. Run `yarn build`. This will create `vega-embed.js` and the minified `vega-embed.min.js`.


### PR DESCRIPTION
Hi! 👋 

This PR serves to add `Number` to the supported types of the `padding` property, as well as to explicitly mention that the installed Yarn version must be Yarn 1 due to the way the `package.json` scripts are prepared. 

Hope it's helpful. Let me know what you think of this PR!

References:

- https://yarnpkg.com/advanced/lifecycle-scripts
- https://classic.yarnpkg.com/en/docs/package-json#toc-scripts