### PR TITLE
improve responsiveness container

### DIFF
--- a/vega-embed.scss
+++ b/vega-embed.scss
@@ -11,7 +11,7 @@
     position: relative;
   }
 
-  details:not([open])> :not(summary) {
+  details:not([open]) > :not(summary) {
     display: none !important;
   }
 

--- a/vega-embed.scss
+++ b/vega-embed.scss
@@ -1,21 +1,22 @@
 .vega-embed {
   position: relative;
-  display: inline-block;
+  display: flex;
   box-sizing: border-box;
 
   &.has-actions {
     padding-right: 38px;
   }
 
-  details:not([open]) > :not(summary) {
+  details {
+    position: relative;
+  }
+
+  details:not([open])> :not(summary) {
     display: none !important;
   }
 
   summary {
     list-style: none;
-    position: absolute;
-    top: 0;
-    right: 0;
     padding: 6px;
     z-index: 1000;
     background: white;
@@ -114,6 +115,7 @@
     &.fit-x {
       width: 100%;
     }
+
     &.fit-y {
       height: 100%;
     }


### PR DESCRIPTION
This PR can be tested using the following npm-test package
- https://www.npmjs.com/package/vega-embed-mattijn
- https://cdn.jsdelivr.net/npm/vega-embed-mattijn@6.

Further section is copied from: https://github.com/altair-viz/altair/pull/2867

* * *

Let me try to break this down.

Within Vega-Lite it is possible to define a fixed width and a _container_ width. Altair uses Vega-Embed for rendering and if we like to support both the fixed width and container width in Altair then there are some changes required to the existing Vega-Embed css by overruling them. 
The question is if these changes can be safely overruled or should they be made in Vega-Embed itself. What do you think @domoritz?

The breakdown is made by the following specification, 
1. Chart `width="container"` (see [gist](https://gist.github.com/mattijn/2fb736d5c8faf8e10d988204cee95a66#file-chart_container-html)) and 
2. Chart `width=200` (see [gist](https://gist.github.com/mattijn/2fb736d5c8faf8e10d988204cee95a66#file-chart_fixed-html))
```python
import altair as alt
from vega_datasets import data

source = data.cars.url

alt.Chart(source, width='container').mark_circle(size=60).encode(
    x='Horsepower:Q',
    y='Miles_per_Gallon:Q',
    color='Origin:N',
).save('chart_container.html')

alt.Chart(source, width=200).mark_circle(size=60).encode(
    x='Horsepower:Q',
    y='Miles_per_Gallon:Q',
    color='Origin:N',
).save('chart_fixed.html')
```

* * *
Without changes to the `.vega-embed` CSS (before this PR) the charts will look like this:

> (1) Chart `width="container"`
> <img width="642" alt="image" src="https://user-images.githubusercontent.com/5186265/217508221-70cdeb5f-323d-49c4-aec7-cc0ab574f747.png">

No width defined on parent, so chart width becomes 0.

> (2) Chart `width=200`
> <img width="642" alt="image" src="https://user-images.githubusercontent.com/5186265/217508584-de886902-29af-48a5-9947-020b328fef33.png">

Renders fine. Action button placed correctly

* * *
Defining `.vega-embed` to a width of 100%:
```css
    .vega-embed {
      width: 100%;
    }
```
Results in:
> (1) Chart `width="container"`
> <img width="686" alt="image" src="https://user-images.githubusercontent.com/5186265/217509790-c86d9683-8b9c-4459-bac1-aa950b9ca8d0.png">

Responsive to the full width, but the open dialog of the action menu is to close to the right browser edge.

> (2) Chart `width=200`
> <img width="642" alt="image" src="https://user-images.githubusercontent.com/5186265/217509607-d6f265f1-f5fa-4ddf-aac8-d9261a9ffad4.png">

Chart renders fine on left-side, but the action button is placed on the right-side.
* * *
Overruling the following [default css](https://github.com/vega/vega-embed/blob/next/vega-embed.scss#L16-L18) from Vega-embed (this PR):

```css
    position: absolute;
    top: 0;
    right: 0;
```
With:
```css
    .vega-embed {
      width: 100%;
      display: flex;
    }

    .vega-embed details,
    .vega-embed details summary {
      position: relative;
    }
```
Results in:
> (1) Chart `width="container"`
> <img width="642" alt="image" src="https://user-images.githubusercontent.com/5186265/217512915-510b26bb-336a-4265-8e0a-92c479075132.png">

Responsive width and action button on the right side, where the dialog is opened with a buffer on the right side.

> (2) Chart `width=200`
> <img width="686" alt="image" src="https://user-images.githubusercontent.com/5186265/217513085-eb290539-3b95-45c2-b0ef-dc55984e11f6.png">

Renders fine. Action button placed correctly