### PR TITLE
feat: smaller bundle and remove es5 builds since they are not really es5 builds anyway

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "files": [
     "src",
     "build",
-    "build-es5",
     "patches"
   ],
   "devDependencies": {
@@ -85,7 +84,7 @@
     "prebuild": "yarn clean && yarn build:style",
     "build": "rollup -c",
     "build:style": "./build-style.sh",
-    "clean": "del-cli build build-es5 src/style.ts",
+    "clean": "del-cli build src/style.ts",
     "prepublishOnly": "yarn clean && yarn build",
     "preversion": "yarn lint && yarn test",
     "serve": "browser-sync start --directory -s -f build *.html",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -18,13 +18,12 @@ const plugins = (browserslist, declaration) => [
       declarationMap: declaration,
     }),
     transpiler: "babel",
-    babelConfig: { presets: ["@babel/preset-env"] },
     browserslist,
   }),
   bundleSize(),
 ];
 
-const outputs = [
+export default [
   {
     input: "src/embed.ts",
     output: {
@@ -32,18 +31,14 @@ const outputs = [
       format: "esm",
       sourcemap: true,
     },
-    plugins: plugins(undefined, true),
+    plugins: plugins(false, true),
     external: [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)],
   },
-];
-
-for (const build of ["es5", "es6"]) {
-  const buildFolder = build === "es5" ? "build-es5" : "build";
-  outputs.push({
+  {
     input: "src/index.ts",
     output: [
       {
-        file: `${buildFolder}/vega-embed.js`,
+        file: "build/vega-embed.js",
         format: "umd",
         sourcemap: true,
         name: "vegaEmbed",
@@ -53,7 +48,7 @@ for (const build of ["es5", "es6"]) {
         },
       },
       {
-        file: `${buildFolder}/vega-embed.min.js`,
+        file: "build/vega-embed.min.js",
         format: "umd", // cannot do iife because rollup generates code that expects Vega-Lite to be present
         sourcemap: true,
         name: "vegaEmbed",
@@ -64,9 +59,7 @@ for (const build of ["es5", "es6"]) {
         plugins: [terser()],
       },
     ],
-    plugins: plugins(build === "es5" ? "defaults" : "defaults and not IE 11", false),
+    plugins: plugins("defaults", false),
     external: ["vega", "vega-lite"],
-  });
-}
-
-export default outputs;
+  },
+];


### PR DESCRIPTION
before: Created bundle vega-embed.module.js: 114.94 kB → 29.03 kB (gzip)
after: Created bundle vega-embed.module.js: 76.41 kB → 20.25 kB (gzip)

fixes #685