### PR TITLE
feat: add explicit exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,17 @@
     "build",
     "patches"
   ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./build/vega-embed.module.d.ts",
+        "default": "./build/vega-embed.module.js"
+      },
+      "require": {
+        "default": "./build/vega-embed.js"
+      }
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.23.6",
     "@babel/plugin-proposal-async-generator-functions": "^7.20.7",


### PR DESCRIPTION
This should allow esm imports. The `module` field is usually used but some bundlers are not preferring it since exports is standardized in node. https://nodejs.org/api/packages.html#package-entry-points

In the future, we could even get rid of the `module` and `main` in favor of just `exports`. 