### PR TITLE
fix: export module with .mjs to fix Vite resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/vega/vega-embed#readme",
   "license": "BSD-3-Clause",
   "main": "build/vega-embed.js",
-  "module": "build/vega-embed.module.js",
+  "module": "build/vega-embed.module.mjs",
   "unpkg": "build/vega-embed.min.js",
   "jsdelivr": "build/vega-embed.min.js",
   "types": "build/src/embed.d.ts",
@@ -41,7 +41,7 @@
     ".": {
       "import": {
         "types": "./build/src/embed.d.ts",
-        "default": "./build/vega-embed.module.js"
+        "default": "./build/vega-embed.module.mjs"
       },
       "require": {
         "default": "./build/vega-embed.js"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,7 +24,7 @@ export default [
   {
     input: "src/embed.ts",
     output: {
-      file: "build/vega-embed.module.js",
+      file: "build/vega-embed.module.mjs",
       format: "esm",
       sourcemap: true,
     },


### PR DESCRIPTION
Vite tries to resolve the module as a CommonJS module because the main package.json does not contain "type": "module". Override this behavior by explicitly adding a .mjs extension.

Locally, this fixes vega/svelte-vega#977 for me.