### PR TITLE
fix: adds `types` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "types": "./build/embed.d.ts",
     "default": "./build/embed.js"
   },
+  "types": "./build/embed.d.ts",
   "unpkg": "build/vega-embed.min.js",
   "jsdelivr": "build/vega-embed.min.js",
   "files": [


### PR DESCRIPTION
Adds `types` back into package.json (removed in #1384) for `compilerOption` backwards compatibility (fixes #1478). 