### PR TITLE
feat: opt-in scheduling option via the Prioritized Task Scheduling API

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ var opt = {
   ast: ...,
   expr: ...,
 
+  scheduling: {
+    signal: ...,
+  },
+
   i18n: {
     COMPILED_ACTION: ...,
     EDITOR_ACTION: ...,
@@ -197,6 +201,7 @@ var opt = {
 | `ast` | Boolean | Generate an [Abstract Syntax Tree (AST)](https://en.wikipedia.org/wiki/Abstract_syntax_tree) instead of expressions and use an interpreter instead of native evaluation. While the interpreter is slower, it adds support for Vega expressions that are [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)-compliant. |
 | `expr` | Object | Custom Vega Expression interpreter. |
 | `viewClass` | Class | Class which extends [Vega `View`](https://vega.github.io/vega/docs/api/view/#view) for custom rendering. |
+| `scheduling` | Boolean / Object | Opt-in (default `false`): chunk the embed pipeline into abortable main-thread tasks using the [Prioritized Task Scheduling API](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API). When enabled, the CPU-heavy phases (compile, parse + view construction, first render, actions menu) are separated by [`scheduler.yield()`](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/yield) so the page stays responsive while embedding complex specs. Parse and view construction share one task: they snapshot Vega's global locale and expression-function registries, which must not change between registration and construction. The option is also passed to the Vega View ([vega/vega#4309](https://github.com/vega/vega/pull/4309)) so dataflow evaluation and canvas rendering yield too: long `runAsync` calls yield periodically and canvas output is drawn to an offscreen buffer that is displayed once rendering completes. On a Vega version without View-level scheduling, only the embed pipeline seams yield. <br> _Boolean_: `true` enables chunking. <br> _Object_: Optional key `signal`, an `AbortSignal` that aborts in-flight embedding at the next stage boundary; `embed()` rejects with the signal's reason and the container is left in its cleared state. <br> Vega-Embed posts no tasks itself: to run the pipeline at a specific [`TaskPriority`](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities), wrap the call in your own task, e.g. `scheduler.postTask(() => vegaEmbed(el, spec, {scheduling: true}), {priority: 'background'})` — the yields inside `embed()` inherit the enclosing task's priority. <br> In [browsers without `scheduler.yield()` support](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler#browser_compatibility), yields fall back to `setTimeout` (task priorities do not apply there). This option is only honored when passed directly to `embed()`; it is stripped from `usermeta.embedOptions`. <br> Do not start another embed into the same element while a scheduled embed is in flight — await the returned promise or abort it first. Inputs rendered into an external `bind` container are not removed on abort. |
 
 ## Common questions
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -27,6 +27,7 @@ import schemaParser from 'vega-schema-url-parser';
 import * as themes from 'vega-themes';
 import {Handler, Options as TooltipOptions} from 'vega-tooltip';
 import post from './post.js';
+import {EmbedSchedulingOptions, ResolvedScheduling, resolveScheduling, yieldToMain} from './scheduler.js';
 import embedStyle from './style.js';
 import {Config, ExpressionFunction, Mode} from './types.js';
 import {mergeDeep} from './util.js';
@@ -35,6 +36,7 @@ import pkg from '../package.json';
 export const version = pkg.version;
 
 export * from './types.js';
+export type {EmbedSchedulingOptions} from './scheduler.js';
 
 export const vega = vegaImport;
 export let vegaLite = vegaLiteImport;
@@ -100,6 +102,7 @@ export interface EmbedOptions<S = string, R = Renderers> {
   expr?: typeof expressionInterpreter;
   viewClass?: typeof View;
   forceActionsMenu?: boolean;
+  scheduling?: boolean | EmbedSchedulingOptions;
 }
 
 const NAMES: {[key in Mode]: string} = {
@@ -221,6 +224,7 @@ function embedOptionsFromUsermeta(parsedSpec: VisualizationSpec) {
     // we don't allow styles set via usermeta since it would allow injection of logic (we set the style via innerHTML)
     opts.defaultStyle = false;
   }
+  delete opts.scheduling;
   return opts;
 }
 
@@ -237,6 +241,10 @@ export default async function embed(
   spec: VisualizationSpec | string,
   opts: EmbedOptions = {},
 ): Promise<Result> {
+  if (Object.hasOwn(opts, 'scheduling')) {
+    resolveScheduling(opts.scheduling).signal?.throwIfAborted();
+  }
+
   let parsedSpec: VisualizationSpec;
   let loader: Loader | undefined;
 
@@ -289,6 +297,46 @@ async function _embed(
   opts: EmbedOptions<never> = {},
   loader: Loader,
 ): Promise<Result> {
+  const scheduling = resolveScheduling(Object.hasOwn(opts, 'scheduling') ? opts.scheduling : undefined);
+
+  if (!scheduling.enabled) {
+    return runEmbedPipeline(el, spec, opts, loader, scheduling);
+  }
+
+  scheduling.signal?.throwIfAborted();
+
+  const viewHolder: ViewHolder = {};
+  try {
+    return await runEmbedPipeline(el, spec, opts, loader, scheduling, viewHolder);
+  } catch (error) {
+    try {
+      viewHolder.view?.finalize();
+    } catch {
+      /* empty */
+    }
+    if (viewHolder.element && containerOwners.get(viewHolder.element) === viewHolder) {
+      viewHolder.element.innerHTML = '';
+      viewHolder.element.classList.remove('vega-embed', 'has-actions', 'fit-x', 'fit-y');
+    }
+    throw error;
+  }
+}
+
+interface ViewHolder {
+  view?: View;
+  element?: Element;
+}
+
+const containerOwners = new WeakMap<Element, ViewHolder>();
+
+async function runEmbedPipeline(
+  el: HTMLElement | string,
+  spec: VisualizationSpec,
+  opts: EmbedOptions<never>,
+  loader: Loader,
+  scheduling: ResolvedScheduling,
+  viewHolder: ViewHolder = {},
+): Promise<Result> {
   const config = opts.theme ? mergeConfig(themes[opts.theme], opts.config ?? {}) : opts.config;
 
   const actions = isBoolean(opts.actions) ? opts.actions : mergeDeep<Actions>({}, DEFAULT_ACTIONS, opts.actions ?? {});
@@ -321,6 +369,10 @@ async function _embed(
 
   const mode = guessMode(spec, logger, opts.mode);
 
+  if (scheduling.enabled) {
+    await yieldToMain(scheduling.signal);
+  }
+
   let vgSpec: VgSpec = PREPROCESSOR[mode](spec, logger, config);
 
   if (mode === 'vega-lite') {
@@ -333,6 +385,8 @@ async function _embed(
     }
   }
 
+  viewHolder.element = element;
+  containerOwners.set(element, viewHolder);
   element.classList.add('vega-embed');
   if (actions) {
     element.classList.add('has-actions');
@@ -350,6 +404,10 @@ async function _embed(
   const patch = opts.patch;
   if (patch) {
     vgSpec = patch instanceof Function ? patch(vgSpec) : applyPatch(vgSpec, patch, true, false).newDocument;
+  }
+
+  if (scheduling.enabled) {
+    await yieldToMain(scheduling.signal);
   }
 
   // Set locale. Note that this is a global setting.
@@ -384,7 +442,9 @@ async function _embed(
     logger,
     renderer,
     ...(ast ? {expr: (vega as any).expressionInterpreter ?? opts.expr ?? expressionInterpreter} : {}),
-  });
+    ...(scheduling.enabled ? {scheduling: {signal: scheduling.signal}} : {}),
+  } as ConstructorParameters<typeof View>[1]);
+  viewHolder.view = view;
 
   view.addSignalListener('autosize', (_, autosize: Exclude<AutoSize, string>) => {
     const {type} = autosize;
@@ -436,11 +496,23 @@ async function _embed(
     }
   }
 
+  if (scheduling.enabled) {
+    await yieldToMain(scheduling.signal);
+  }
+
   await view.initialize(container, opts.bind).runAsync();
+
+  if (scheduling.enabled) {
+    scheduling.signal?.throwIfAborted();
+  }
 
   let documentClickHandler: ((this: Document, ev: MouseEvent) => void) | undefined;
 
   if (actions !== false) {
+    if (scheduling.enabled) {
+      await yieldToMain(scheduling.signal);
+    }
+
     let wrapper = element;
 
     if (opts.defaultStyle !== false || opts.forceActionsMenu) {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,29 @@
+export interface EmbedSchedulingOptions {
+  signal?: AbortSignal;
+}
+
+export interface ResolvedScheduling {
+  enabled: boolean;
+  signal?: AbortSignal;
+}
+
+export function resolveScheduling(scheduling?: boolean | EmbedSchedulingOptions): ResolvedScheduling {
+  if (scheduling === true) {
+    return {enabled: true, signal: undefined};
+  }
+  if (typeof scheduling !== 'object' || scheduling === null) {
+    return {enabled: false, signal: undefined};
+  }
+  return {enabled: true, signal: scheduling.signal};
+}
+
+export async function yieldToMain(signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  const schedulerGlobal = globalThis.scheduler as Scheduler | undefined;
+  if (typeof schedulerGlobal?.yield === 'function') {
+    await schedulerGlobal.yield();
+  } else {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  signal?.throwIfAborted();
+}

--- a/test-scheduling.html
+++ b/test-scheduling.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vega-Embed Scheduling</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/vega@6"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@6"></script>
+    <script src="build/vega-embed.min.js"></script>
+  </head>
+
+  <body>
+    <p>
+      Open DevTools and record a Performance trace while reloading. With <code>scheduling: true</code>, the embed work
+      appears as multiple tasks instead of one long task. In browsers without the Prioritized Task Scheduling API,
+      yields fall back to <code>setTimeout</code>.
+    </p>
+    <button id="abort">Abort in-flight embed</button>
+    <div id="vis"></div>
+    <script>
+      async function run() {
+        const values = Array.from({length: 100000}, (_, i) => ({
+          x: i % 1000,
+          y: Math.random() * 100 + (i % 7) * 10,
+          category: `series-${i % 7}`,
+        }));
+
+        const spec = {
+          $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+          data: {values},
+          mark: 'point',
+          encoding: {
+            x: {field: 'x', type: 'quantitative'},
+            y: {field: 'y', type: 'quantitative'},
+            color: {field: 'category', type: 'nominal'},
+          },
+        };
+
+        const controller = new AbortController();
+        document.getElementById('abort').addEventListener('click', () => controller.abort(new Error('user aborted')));
+
+        performance.mark('embed-start');
+        try {
+          // vega-embed posts no tasks itself; wrapping the call in postTask sets the priority
+          // that the scheduler.yield() calls inside the pipeline inherit
+          const result = await scheduler.postTask(
+            () =>
+              vegaEmbed('#vis', spec, {
+                // canvas renderer: 100k points as SVG would create 100k DOM nodes and crash the tab
+                renderer: 'canvas',
+                // scheduling forwards to the Vega View (vega/vega#4309): released vega ignores it
+                scheduling: {signal: controller.signal},
+              }),
+            {priority: 'user-visible'},
+          );
+          performance.mark('embed-end');
+          performance.measure('vega-embed scheduled', 'embed-start', 'embed-end');
+          console.log(result);
+        } catch (error) {
+          console.log('embed aborted or failed:', error);
+        }
+      }
+      run();
+    </script>
+  </body>
+</html>

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -3,8 +3,9 @@ import {View, Spec as VgSpec, logger} from 'vega';
 import {expressionInterpreter} from 'vega-interpreter';
 import * as vl from 'vega-lite';
 import {compile, TopLevelSpec} from 'vega-lite';
-import {expect, test, vi} from 'vitest';
+import {afterEach, expect, test, vi} from 'vitest';
 import embed, {guessMode, Mode} from '../src/embed';
+import {createSchedulerStub} from './scheduler-stub';
 
 const vlSpec: TopLevelSpec = {
   data: {values: [1, 2, 3]},
@@ -15,6 +16,10 @@ const vlSpec: TopLevelSpec = {
 const vgSpec = compile(vlSpec).spec;
 
 const testLogger = logger(vega.Warn);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 const vlSpecCustomFunction: TopLevelSpec = {
   data: {values: [1, 2, 3]},
@@ -567,4 +572,323 @@ test('can set custom logger', async () => {
   expect(spy.mock.calls).toEqual([['test']]);
 
   spy.mockRestore();
+});
+
+test('scheduling embeds successfully via the setTimeout fallback when no scheduler global exists', async () => {
+  expect(globalThis.scheduler).toBeUndefined();
+  const el = document.createElement('div');
+  const result = await embed(el, vlSpec, {scheduling: true});
+  expect(result.view).toBeDefined();
+});
+
+test('scheduling produces the same result shape and DOM as the default path', async () => {
+  const defaultEl = document.createElement('div');
+  const defaultResult = await embed(defaultEl, vlSpec);
+
+  const {stub} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const scheduledEl = document.createElement('div');
+  const scheduledResult = await embed(scheduledEl, vlSpec, {scheduling: true});
+
+  expect(scheduledResult.view).toBeDefined();
+  expect(scheduledResult.spec).toEqual(defaultResult.spec);
+  expect(scheduledResult.vgSpec).toEqual(defaultResult.vgSpec);
+  expect(scheduledResult.finalize).toBeDefined();
+
+  // vega generates globally unique clip ids, so normalize them before comparing markup
+  const normalizeIds = (html: string) => html.replace(/clip\d+/g, 'clip');
+  expect(normalizeIds(scheduledEl.innerHTML)).toBe(normalizeIds(defaultEl.innerHTML));
+});
+
+test('scheduling: true yields at every stage seam and posts no tasks', async () => {
+  const {stub, calls} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+  // the stub's postTask throws, so completing proves embed never posts a task
+  await embed(el, vlSpec, {scheduling: true});
+
+  // compile, parse + view construction (one task: global locale/expression-function
+  // registration must not be separated from the parse/construction that snapshots it),
+  // first render, actions menu
+  expect(calls.yield).toBe(4);
+});
+
+test('locale registration, parse, and view construction share one task', async () => {
+  const {stub, calls} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  let yieldsBeforeViewConstruction = -1;
+  class RecordingView extends View {
+    constructor(...args: ConstructorParameters<typeof View>) {
+      super(...args);
+      yieldsBeforeViewConstruction = calls.yield;
+    }
+  }
+  const el = document.createElement('div');
+  await embed(el, vlSpec, {scheduling: true, viewClass: RecordingView});
+
+  // the view must be constructed in the continuation of the second yield — a third yield
+  // before construction would reopen the global locale/expression-function race
+  expect(yieldsBeforeViewConstruction).toBe(2);
+});
+
+test('scheduling is forwarded to the View constructor so vega evaluation and rendering can yield', async () => {
+  const {stub} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const controller = new AbortController();
+  let viewOptions: Record<string, unknown> | undefined;
+  class RecordingView extends View {
+    constructor(...args: ConstructorParameters<typeof View>) {
+      super(...args);
+      viewOptions = args[1] as Record<string, unknown>;
+    }
+  }
+  const el = document.createElement('div');
+  await embed(el, vlSpec, {
+    scheduling: {signal: controller.signal},
+    viewClass: RecordingView,
+  });
+
+  expect(viewOptions?.scheduling).toEqual({signal: controller.signal});
+});
+
+test('the View constructor receives no scheduling option when scheduling is disabled', async () => {
+  let viewOptions: Record<string, unknown> | undefined;
+  class RecordingView extends View {
+    constructor(...args: ConstructorParameters<typeof View>) {
+      super(...args);
+      viewOptions = args[1] as Record<string, unknown>;
+    }
+  }
+  const el = document.createElement('div');
+  await embed(el, vlSpec, {viewClass: RecordingView});
+
+  expect(viewOptions).toBeDefined();
+  expect('scheduling' in (viewOptions as Record<string, unknown>)).toBe(false);
+});
+
+test('a present scheduler stub records zero calls when scheduling is disabled', async () => {
+  const {stub, calls} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+  await embed(el, vlSpec);
+
+  expect(calls.yield).toBe(0);
+});
+
+test('an already-aborted scheduling signal rejects before any DOM mutation', async () => {
+  const {stub, calls} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+  const existingChild = document.createElement('span');
+  el.appendChild(existingChild);
+  const reason = new Error('cancelled before start');
+  const controller = new AbortController();
+  controller.abort(reason);
+
+  await expect(embed(el, vlSpec, {scheduling: {signal: controller.signal}})).rejects.toBe(reason);
+  expect(el.classList.contains('vega-embed')).toBe(false);
+  expect(Array.from(el.children)).toEqual([existingChild]);
+  expect(calls.yield).toBe(0);
+});
+
+test('aborting at the first yield stops embedding before any actions menu is added', async () => {
+  const {stub} = createSchedulerStub();
+  const reason = new Error('stop embedding');
+  const controller = new AbortController();
+  stub.yield = () => {
+    controller.abort(reason);
+    return Promise.resolve();
+  };
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+
+  await expect(embed(el, vlSpec, {scheduling: {signal: controller.signal}})).rejects.toBe(reason);
+  expect(el.querySelector('.vega-actions')).toBeNull();
+});
+
+// finalizing the already-constructed view on abort is what prevents listener and dataflow timer leaks
+test('aborting after the view is constructed finalizes the view and rejects with the custom reason', async () => {
+  const finalizeSpy = vi.spyOn(View.prototype, 'finalize');
+  const {stub} = createSchedulerStub();
+  // custom non-Error reason must surface unchanged, not a synthesized error
+  const reason = 'custom abort reason';
+  const controller = new AbortController();
+  let yields = 0;
+  stub.yield = () => {
+    yields++;
+    if (yields === 3) {
+      controller.abort(reason);
+    }
+    return Promise.resolve();
+  };
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+
+  await expect(embed(el, vlSpec, {scheduling: {signal: controller.signal}})).rejects.toBe(reason);
+  expect(yields).toBe(3);
+  expect(finalizeSpy).toHaveBeenCalledTimes(1);
+  finalizeSpy.mockRestore();
+});
+
+test('aborting after embed has resolved has no effect', async () => {
+  const {stub} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const controller = new AbortController();
+  const el = document.createElement('div');
+
+  const result = await embed(el, vlSpec, {scheduling: {signal: controller.signal}});
+  controller.abort(new Error('too late'));
+
+  expect(el.querySelector('svg')).not.toBeNull();
+  expect(el.querySelector('.vega-actions')).not.toBeNull();
+  expect(() => result.finalize()).not.toThrow();
+});
+
+test('scheduling builds the complete actions menu after the final yield', async () => {
+  const {stub} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+  await embed(el, vlSpec, {scheduling: true});
+
+  expect(el.children[1].tagName).toBe('DETAILS');
+  expect(el.children[1].children[1].classList[0]).toBe('vega-actions');
+  expect(el.children[1].children[1].childElementCount).toBe(5);
+});
+
+test('scheduling with actions disabled skips the actions-menu yield', async () => {
+  const {stub, calls} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+  await embed(el, vlSpec, {scheduling: true, actions: false});
+
+  expect(calls.yield).toBe(3);
+});
+
+// embed() checks the signal before any spec/config fetch so a pre-aborted embed does no network work
+test('an already-aborted signal prevents loading a URL spec', async () => {
+  const reason = new Error('cancelled before load');
+  const controller = new AbortController();
+  controller.abort(reason);
+  const load = vi.fn();
+  const el = document.createElement('div');
+
+  await expect(
+    embed(el, 'https://example.com/spec.json', {loader: {load} as never, scheduling: {signal: controller.signal}}),
+  ).rejects.toBe(reason);
+  expect(load).not.toHaveBeenCalled();
+});
+
+test('aborting during the first render rejects even with actions disabled', async () => {
+  const finalizeSpy = vi.spyOn(View.prototype, 'finalize');
+  const {stub} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const reason = new Error('abort mid-render');
+  const controller = new AbortController();
+  const runAsyncSpy = vi.spyOn(View.prototype, 'runAsync').mockImplementation(function (this: View) {
+    controller.abort(reason);
+    return Promise.resolve(this);
+  });
+  const el = document.createElement('div');
+
+  await expect(embed(el, vlSpec, {actions: false, scheduling: {signal: controller.signal}})).rejects.toBe(reason);
+  expect(finalizeSpy).toHaveBeenCalledTimes(1);
+  expect(el.classList).toHaveLength(0);
+  expect(el.children).toHaveLength(0);
+  runAsyncSpy.mockRestore();
+  finalizeSpy.mockRestore();
+});
+
+test('a genuine pipeline error with scheduling enabled propagates and clears the container', async () => {
+  const {stub} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const failure = new Error('render exploded');
+  const runAsyncSpy = vi.spyOn(View.prototype, 'runAsync').mockRejectedValue(failure);
+  const el = document.createElement('div');
+
+  await expect(embed(el, vlSpec, {scheduling: true})).rejects.toBe(failure);
+  expect(el.children).toHaveLength(0);
+  expect(el.classList).toHaveLength(0);
+  runAsyncSpy.mockRestore();
+});
+
+test('a throwing finalize during abort cleanup neither masks the reason nor skips the reset', async () => {
+  const finalizeSpy = vi.spyOn(View.prototype, 'finalize').mockImplementation(() => {
+    throw new Error('finalize exploded');
+  });
+  const {stub} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const reason = new Error('abort mid-render');
+  const controller = new AbortController();
+  const runAsyncSpy = vi.spyOn(View.prototype, 'runAsync').mockImplementation(function (this: View) {
+    controller.abort(reason);
+    return Promise.resolve(this);
+  });
+  const el = document.createElement('div');
+
+  await expect(embed(el, vlSpec, {actions: false, scheduling: {signal: controller.signal}})).rejects.toBe(reason);
+  expect(el.children).toHaveLength(0);
+  expect(el.classList).toHaveLength(0);
+  runAsyncSpy.mockRestore();
+  finalizeSpy.mockRestore();
+});
+
+// abort cleanup resets the container only while this embed still owns it (containerOwners): a newer
+// embed can take ownership of the element while the aborted one is parked at a yield
+test('a delayed abort cleanup does not wipe a newer embed into the same element', async () => {
+  const {stub} = createSchedulerStub();
+  const reason = new Error('superseded');
+  const controller = new AbortController();
+  let releaseParkedYield!: () => void;
+  const parkedYield = new Promise<void>((resolve) => {
+    releaseParkedYield = resolve;
+  });
+  let yields = 0;
+  stub.yield = () => {
+    yields++;
+    // park the first embed at the seam after it has claimed the element (yield 2, before the
+    // parse/view-construction task)
+    return yields === 2 ? parkedYield : Promise.resolve();
+  };
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+
+  const first = embed(el, vlSpec, {scheduling: {signal: controller.signal}});
+  while (yields < 2) {
+    await new Promise((resolve) => setTimeout(resolve));
+  }
+  controller.abort(reason);
+
+  const second = await embed(el, vlSpec);
+  // the first embed stays parked until released, so its rejection settles only after the
+  // assertion below has attached its handler
+  releaseParkedYield();
+  await expect(first).rejects.toBe(reason);
+
+  expect(second.view).toBeDefined();
+  expect(el.querySelector('svg')).not.toBeNull();
+  expect(el.classList.contains('vega-embed')).toBe(true);
+});
+
+test('aborting at the actions-menu boundary clears the container', async () => {
+  const finalizeSpy = vi.spyOn(View.prototype, 'finalize');
+  const {stub} = createSchedulerStub();
+  const reason = new Error('late abort');
+  const controller = new AbortController();
+  let yields = 0;
+  stub.yield = () => {
+    yields++;
+    // the fourth yield is the seam right before the actions menu is built
+    if (yields === 4) {
+      controller.abort(reason);
+    }
+    return Promise.resolve();
+  };
+  vi.stubGlobal('scheduler', stub);
+  const el = document.createElement('div');
+
+  await expect(embed(el, vlSpec, {scheduling: {signal: controller.signal}})).rejects.toBe(reason);
+  expect(finalizeSpy).toHaveBeenCalledTimes(1);
+  expect(el.children).toHaveLength(0);
+  expect(el.classList).toHaveLength(0);
+  finalizeSpy.mockRestore();
 });

--- a/test/scheduler-stub.ts
+++ b/test/scheduler-stub.ts
@@ -1,0 +1,25 @@
+export interface SchedulerStubCalls {
+  yield: number;
+}
+
+/**
+ * jsdom has no Prioritized Task Scheduling API. This hand-rolled stub resolves
+ * `yield` immediately and counts calls so tests can assert how often the
+ * pipeline yielded. vega-embed must never post tasks itself (consumers wrap
+ * `embed()` in their own `scheduler.postTask`), so `postTask` throws.
+ */
+export function createSchedulerStub(): {stub: Scheduler; calls: SchedulerStubCalls} {
+  const calls: SchedulerStubCalls = {yield: 0};
+
+  const stub: Scheduler = {
+    postTask() {
+      throw new Error('vega-embed must not call scheduler.postTask');
+    },
+    yield() {
+      calls.yield++;
+      return Promise.resolve();
+    },
+  };
+
+  return {stub, calls};
+}

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -1,0 +1,120 @@
+import {TopLevelSpec} from 'vega-lite';
+import {afterEach, expect, test, vi} from 'vitest';
+import embed from '../src/embed';
+import {resolveScheduling, yieldToMain} from '../src/scheduler';
+import {createSchedulerStub} from './scheduler-stub';
+
+const vlSpec: TopLevelSpec = {
+  data: {values: [1, 2, 3]},
+  encoding: {},
+  mark: 'point',
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('resolveScheduling treats undefined and false as disabled', () => {
+  expect(resolveScheduling(undefined).enabled).toBe(false);
+  expect(resolveScheduling(false).enabled).toBe(false);
+});
+
+test('resolveScheduling treats true as enabled without a signal', () => {
+  expect(resolveScheduling(true)).toEqual({enabled: true, signal: undefined});
+});
+
+test('resolveScheduling passes the signal through so aborts reach the pipeline seams', () => {
+  const controller = new AbortController();
+  expect(resolveScheduling({signal: controller.signal})).toEqual({
+    enabled: true,
+    signal: controller.signal,
+  });
+  expect(resolveScheduling({}).signal).toBeUndefined();
+});
+
+test('yieldToMain resolves and yields once', async () => {
+  const {stub, calls} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  await expect(yieldToMain()).resolves.toBeUndefined();
+  expect(calls.yield).toBe(1);
+});
+
+test('yieldToMain throws the signal reason without yielding when already aborted', async () => {
+  const {stub, calls} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  const reason = new Error('stop embedding');
+  const controller = new AbortController();
+  controller.abort(reason);
+  await expect(yieldToMain(controller.signal)).rejects.toBe(reason);
+  expect(calls.yield).toBe(0);
+});
+
+test('yieldToMain throws the signal reason when the signal aborts while parked', async () => {
+  const {stub} = createSchedulerStub();
+  const reason = new Error('stop embedding');
+  const controller = new AbortController();
+  stub.yield = () => {
+    controller.abort(reason);
+    return Promise.resolve();
+  };
+  vi.stubGlobal('scheduler', stub);
+  await expect(yieldToMain(controller.signal)).rejects.toBe(reason);
+});
+
+// scheduling must be opted into by the embedding page: spec content must not be able to change
+// how the host page's main thread is chunked or carry an AbortSignal
+test('usermeta cannot enable scheduling', async () => {
+  expect(globalThis.scheduler).toBeUndefined();
+  const el = document.createElement('div');
+  const result = await embed(el, {
+    ...vlSpec,
+    usermeta: {
+      embedOptions: {
+        scheduling: true,
+      },
+    },
+  });
+  expect(result).toBeTruthy();
+  expect(result.embedOptions.scheduling).toBeUndefined();
+});
+
+test('resolveScheduling treats null and other falsy non-false values as disabled', () => {
+  expect(resolveScheduling(null as never).enabled).toBe(false);
+  expect(resolveScheduling(0 as never).enabled).toBe(false);
+  expect(resolveScheduling('' as never).enabled).toBe(false);
+});
+
+test('yieldToMain falls back to setTimeout without a scheduler global', async () => {
+  expect(globalThis.scheduler).toBeUndefined();
+  const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+  await expect(yieldToMain()).resolves.toBeUndefined();
+  expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+  setTimeoutSpy.mockRestore();
+});
+
+test('yieldToMain falls back to setTimeout for a partial scheduler missing yield', async () => {
+  const {stub} = createSchedulerStub();
+  vi.stubGlobal('scheduler', {postTask: stub.postTask});
+  const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+  await expect(yieldToMain()).resolves.toBeUndefined();
+  expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+  setTimeoutSpy.mockRestore();
+});
+
+test('an inherited scheduling property cannot enable scheduling', async () => {
+  // a recording stub is installed so a broken hasOwn guard cannot slip through via the
+  // setTimeout fallback: zero recorded yields proves scheduling stayed disabled
+  const {stub, calls} = createSchedulerStub();
+  vi.stubGlobal('scheduler', stub);
+  // simulate prototype pollution reachable through usermeta option merging; non-enumerable so
+  // vega's own object iteration is unaffected and only the inherited-read path is exercised
+  Object.defineProperty(Object.prototype, 'scheduling', {value: true, configurable: true, enumerable: false});
+  try {
+    const el = document.createElement('div');
+    const result = await embed(el, vlSpec);
+    expect(result).toBeTruthy();
+    expect(calls.yield).toBe(0);
+  } finally {
+    delete (Object.prototype as Record<string, unknown>).scheduling;
+  }
+});


### PR DESCRIPTION
## Summary

For complex specs, `embed()` runs its CPU-heavy phases — `vegaLite.compile`, `vega.parse`, `View` construction, and the first `runAsync()` render — back-to-back, so the browser sees one main-thread task of hundreds of milliseconds and input handling is blocked for the whole span. This PR adds an opt-in `scheduling` option that inserts [`scheduler.yield()`](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/yield) at the phase boundaries and forwards the option to the Vega `View` ([vega/vega#4309](https://github.com/vega/vega/pull/4309)), so Vega's own evaluation and canvas rendering break into short tasks too. In-flight embedding becomes abortable.

`scheduling` is off by default and the default path is unchanged — no scheduler interaction, no added awaits.

```js
const controller = new AbortController();
const result = await embed(el, spec, {
  scheduling: {signal: controller.signal},
});
```

## Design decisions

- **Opt-in `boolean | EmbedSchedulingOptions`**, mirroring the existing `actions`/`tooltip`/`hover` shape. `true` enables chunking; the object form adds an optional `signal`.
- **Yields only — vega-embed posts no tasks.** The pipeline yields at four seams: before compile, after compile and patching, before the first render, and before the actions menu. To run at a specific `TaskPriority`, wrap the `embed()` call in your own `scheduler.postTask()` — the yields inherit the enclosing task's priority. Priority policy stays with the host page.
- **The option is forwarded to the `View`**, so `runAsync` yields during dataflow evaluation and canvas output is drawn offscreen and displayed once rendering completes. On a Vega version without View-level scheduling the extra key is ignored and only the embed seams yield.
- **Parse and `View` construction share one task.** Locale and expression-function registration mutate vega's process-wide registries, which parse and `View` construction snapshot; a yield in between would let a concurrent embed swap them mid-flight.
- **`setTimeout` fallback** where `scheduler.yield` is unavailable — chunking still works, priorities simply don't apply. No polyfill needed.
- **Abort at stage boundaries.** `scheduling.signal` aborts at the next yield: `embed()` rejects with the signal's reason, an already-constructed `View` is finalized (a throwing `finalize` neither masks the reason nor skips cleanup), and the container is restored to its cleared state — unless a newer embed has taken ownership of the element, in which case the stale cleanup leaves it alone. An already-aborted signal rejects before any DOM mutation or spec/config fetch.
- **Spec content can never enable scheduling.** `usermeta.embedOptions.scheduling` is stripped during usermeta loading (same rationale as the existing `defaultStyle` sanitization), and the option is read with an `Object.hasOwn` guard so a polluted `Object.prototype` cannot switch it on.

## Known limitations

- Starting another embed into the same element while a scheduled embed is in flight is unsupported — await the returned promise or abort it first (a delayed abort cleanup at least won't wipe the newer embed's output).
- Inputs rendered into an external `bind` container are not removed on abort.
- jsdom tests use a recording scheduler stub, so real `yield` timing, priority inheritance, and View-level slicing are covered only by the manual Chrome smoke page.
