### PR TITLE
fix: stretch the root only for container-sized charts

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -388,16 +388,16 @@ async function _embed(
 
   view.addSignalListener('autosize', (_, autosize: Exclude<AutoSize, string>) => {
     const {type} = autosize;
-    if (type == 'fit-x') {
-      container.classList.add('fit-x');
-      container.classList.remove('fit-y');
-    } else if (type == 'fit-y') {
-      container.classList.remove('fit-x');
-      container.classList.add('fit-y');
-    } else if (type == 'fit') {
-      container.classList.add('fit-x', 'fit-y');
-    } else {
-      container.classList.remove('fit-x', 'fit-y');
+    const fitX = type == 'fit-x' || type == 'fit';
+    const fitY = type == 'fit-y' || type == 'fit';
+
+    // Mark the chart wrapper so it can fill, and the root so it can become a
+    // full-width block. Only container-sized charts stretch the root, which keeps
+    // the actions menu next to the chart for fixed-size ones. When actions are
+    // disabled there is no wrapper and both are the same element.
+    for (const target of new Set([container, element])) {
+      target.classList.toggle('fit-x', fitX);
+      target.classList.toggle('fit-y', fitY);
     }
   });
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -391,10 +391,8 @@ async function _embed(
     const fitX = type == 'fit-x' || type == 'fit';
     const fitY = type == 'fit-y' || type == 'fit';
 
-    // Mark the chart wrapper so it can fill, and the root so it can become a
-    // full-width block. Only container-sized charts stretch the root, which keeps
-    // the actions menu next to the chart for fixed-size ones. When actions are
-    // disabled there is no wrapper and both are the same element.
+    // Mark the chart wrapper and the root (the same element when actions are
+    // disabled) so the CSS can stretch them.
     for (const target of new Set([container, element])) {
       target.classList.toggle('fit-x', fitX);
       target.classList.toggle('fit-y', fitY);

--- a/vega-embed.scss
+++ b/vega-embed.scss
@@ -3,11 +3,8 @@
   display: inline-block;
   box-sizing: border-box;
 
-  // Container-sized charts have to fill the parent. `.chart-wrapper.fit-x` sizes
-  // itself with `width: 100%`, which only resolves against a root with a definite
-  // width — an inline-block root is shrink-to-fit, so it would resolve to 0.
-  // embed.ts sets `fit-x` on the root too, so only container-sized charts stretch
-  // it; fixed-size charts keep the shrink-to-fit root and their actions menu.
+  // Stretch the root for container-sized charts so the chart wrapper's
+  // `width: 100%` resolves against a definite width instead of shrink-to-fit.
   &.fit-x {
     display: block;
     width: 100%;

--- a/vega-embed.scss
+++ b/vega-embed.scss
@@ -3,6 +3,16 @@
   display: inline-block;
   box-sizing: border-box;
 
+  // Container-sized charts have to fill the parent. `.chart-wrapper.fit-x` sizes
+  // itself with `width: 100%`, which only resolves against a root with a definite
+  // width — an inline-block root is shrink-to-fit, so it would resolve to 0.
+  // embed.ts sets `fit-x` on the root too, so only container-sized charts stretch
+  // it; fixed-size charts keep the shrink-to-fit root and their actions menu.
+  &.fit-x {
+    display: block;
+    width: 100%;
+  }
+
   &.has-actions {
     padding-right: 38px;
   }


### PR DESCRIPTION
`.chart-wrapper.fit-x` sizes itself with `width: 100%`, but the `.vega-embed` root is `inline-block` — shrink-to-fit — so the percentage resolved to 0 and `"width": "container"` charts rendered 0px wide. The autosize listener now marks the root with `fit-x` / `fit-y` too, and `.vega-embed.fit-x` becomes a full-width block. Only container-sized charts stretch the root, so fixed-size charts keep their shrink-to-fit root and their actions menu position.

In an 876px parent, a container-sized chart goes from root / wrapper / canvas / `width` signal = 38 / 0 / 0 / 0 to 876 / 838 / 838 / 794. Fixed-size charts are byte-identical to `main` across block, flex, grid, and centered parents, with and without actions.

Closes #1066 — same bug, different route, with thanks to @mattijn for diagnosing it.

`"height": "container"` is still broken and out of scope: percentage heights need a definite parent height, so it needs its own change.
